### PR TITLE
Slight manifest reorganization and added itl-hazard-mgr to the manifest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -39,6 +39,8 @@ manifest:
       url-base: git@github.com:Intellinium
     - name: intellinium-space-ml
       url-base: git@git.jetbrains.space:intellinium/pod-machine-learning
+    - name: intellinium-space-embedded
+      url-base: git@git.jetbrains.space:intellinium/embedded
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -209,6 +211,10 @@ manifest:
       remote: intellinium-space-ml
       revision: functionality_optimization
       path: modules/itl-ml/ml-tflite-toolbox
+    - name: itl-hazard-mgr
+      remote: intellinium-space-embedded
+      revision: 7aa7514280d3987befa35df78399e8c8cb8f9f0a
+      path: modules/itl-hazard-mgr
 
   # West-related configuration for the nrf repository.
   self:

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       path: modules/itl-ml/ml-tflite-toolbox
     - name: itl-hazard-mgr
       remote: intellinium-space-embedded
-      revision: 7aa7514280d3987befa35df78399e8c8cb8f9f0a
+      revision: db31ecfefab3de8f379c6507802a93b8be44d237
       path: modules/itl-hazard-mgr
 
   # West-related configuration for the nrf repository.

--- a/west.yml
+++ b/west.yml
@@ -31,14 +31,14 @@ manifest:
       url-base: https://github.com/alexa
     - name: nordicsemi
       url-base: https://github.com/NordicSemiconductor
-    - name: intellinium
-      url-base: git@github.com:Intellinium
-    - name: intellinium-space-ml
-      url-base: git@git.jetbrains.space:intellinium/pod-machine-learning
     - name: pelioniot
       url-base: https://github.com/PelionIoT
     - name: memfault
       url-base: https://github.com/memfault
+    - name: intellinium-github
+      url-base: git@github.com:Intellinium
+    - name: intellinium-space-ml
+      url-base: git@git.jetbrains.space:intellinium/pod-machine-learning
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -58,7 +58,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      remote: intellinium
+      remote: intellinium-github
       revision: 08bb0655b9c354761d4de885ab55fcd98e8af94a
 
       import:
@@ -175,22 +175,6 @@ manifest:
       remote: nordicsemi
       revision: 24f1b2b0c64c694b7f9ac1b7eab60b39236ca0bf
       path: modules/lib/cddl-gen
-    - name: hal_intellinium
-      remote: intellinium
-      revision: 4075d9581d0e970b0315027ab40e0cf3a6c9a433
-      path: modules/hal/intellinium
-    - name: embedded-itl-lib
-      remote: intellinium
-      revision: gauge_multi_inst
-      path: modules/itl-lib
-    - name: ml-ppg-algorithm
-      remote: intellinium
-      revision: 49f09069eb8fa66de0d1d9b7cd1f38b9d4fee441
-      path: modules/itl-ml/ppg
-    - name: ml-ppg-cognitive-test
-      remote: intellinium
-      revision: 7ca9059aa507dc7b57bad150c8fc101d935968f1
-      path: modules/itl-ml/ppg_ct
     - name: homekit
       repo-path: sdk-homekit
       revision: v1.6.0
@@ -201,14 +185,30 @@ manifest:
       revision: v1.6.0
       groups:
       - find-my
-    - name: ml-tflite-toolbox
-      remote: intellinium-space-ml
-      revision: functionality_optimization
-      path: modules/itl-ml/ml-tflite-toolbox
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
       revision: 0.21.1
       remote: memfault
+    - name: hal_intellinium
+      remote: intellinium-github
+      revision: 4075d9581d0e970b0315027ab40e0cf3a6c9a433
+      path: modules/hal/intellinium
+    - name: embedded-itl-lib
+      remote: intellinium-github
+      revision: gauge_multi_inst
+      path: modules/itl-lib
+    - name: ml-ppg-algorithm
+      remote: intellinium-github
+      revision: 49f09069eb8fa66de0d1d9b7cd1f38b9d4fee441
+      path: modules/itl-ml/ppg
+    - name: ml-ppg-cognitive-test
+      remote: intellinium-github
+      revision: 7ca9059aa507dc7b57bad150c8fc101d935968f1
+      path: modules/itl-ml/ppg_ct
+    - name: ml-tflite-toolbox
+      remote: intellinium-space-ml
+      revision: functionality_optimization
+      path: modules/itl-ml/ml-tflite-toolbox
 
   # West-related configuration for the nrf repository.
   self:


### PR DESCRIPTION
The manifest reorganization is made in a separate commit in case you prefer not to include it.