### PR TITLE
Fixed wrong commit for itl_hazard_mgr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       path: modules/itl-ml/ml-tflite-toolbox
     - name: itl-hazard-mgr
       remote: intellinium-space-embedded
-      revision: db31ecfefab3de8f379c6507802a93b8be44d237
+      revision: d5e1f57986f3ff5d4ba1a5f4bf55ef5f30d68845
       path: modules/itl-hazard-mgr
 
   # West-related configuration for the nrf repository.


### PR DESCRIPTION
Strangely, the revision in the manifest for hazard-mgr referred to nothing existent. This is now fixed. This correspond to the second initial commit.