### PR TITLE
Revert "west.yml: remove tensorflow from zephyr allowlist"

### DIFF
--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -487,5 +487,4 @@ _BLOCKED_PROJECTS = set(
      'modules/hal/stm32',
      'modules/hal/ti',
      'modules/hal/xtensa',
-     'modules/lib/tensorflow',
      ])

--- a/west.yml
+++ b/west.yml
@@ -210,7 +210,7 @@ manifest:
       path: modules/itl-ml/ppg_ct
     - name: ml-tflite-toolbox
       remote: intellinium-space-ml
-      revision: functionality_optimization
+      revision: add_multiple_model_support
       path: modules/itl-ml/ml-tflite-toolbox
     - name: itl-hazard-mgr
       remote: intellinium-space-embedded

--- a/west.yml
+++ b/west.yml
@@ -95,6 +95,7 @@ manifest:
           - nrf_hw_models
           - open-amp
           - segger
+          - tensorflow
           - tinycbor
           - tinycrypt
           - TraceRecorderSource


### PR DESCRIPTION
This reverts commit 3604331caaf170fe4f22ea427396a50c4a43b907.

tensorflow has been removed from sdk_nrf as it was considered irrelevant to their project but it is needed for Peng's work so this adds it back.