### PR TITLE
Removed ml-tflite-toolbox from the manifest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -207,10 +207,6 @@ manifest:
       remote: intellinium-github
       revision: 7ca9059aa507dc7b57bad150c8fc101d935968f1
       path: modules/itl-ml/ppg_ct
-    - name: ml-tflite-toolbox
-      remote: intellinium-space-ml
-      revision: functionality_optimization
-      path: modules/itl-ml/ml-tflite-toolbox
     - name: itl-hazard-mgr
       remote: intellinium-space-embedded
       revision: dev-stable


### PR DESCRIPTION
This project is now included in itl-lib and should not be here anymore.